### PR TITLE
(refactor) actions now specify version differently

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,33 +1,29 @@
-on:
-  pull_request:
-    branches:
-    - master
+name: 'Terraform checks'
 
-name: CI
+on:
+  - pull_request
 jobs:
-  filter-to-pr-open-synced:
+  terraform:
+    name: 'terraform'
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
-    - name: filter-to-pr-open-synced
-      uses: actions/bin/filter@master
-      with:
-        args: action 'opened|synchronize'
-    - name: terraform-fmt
+    - name: 'checkout'
+      uses: actions/checkout@master
+    - name: format
       uses: hashicorp/terraform-github-actions@master
       with:
         tf_actions_version: 0.12.24
         tf_actions_subcommand: 'fmt'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    - name: terraform-init
+    - name: init
       uses: hashicorp/terraform-github-actions@master
       with:
         tf_actions_version: 0.12.24
         tf_actions_subcommand: 'init'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    - name: terraform-validate
+    - name: validate
       uses: hashicorp/terraform-github-actions@master
       with:
         tf_actions_version: 0.12.24

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,17 +14,23 @@ jobs:
       with:
         args: action 'opened|synchronize'
     - name: terraform-fmt
-      uses: hashicorp/terraform-github-actions/fmt@v0.4.0
+      uses: hashicorp/terraform-github-actions@master
+      with:
+        tf_actions_version: 0.12.24
+        tf_actions_subcommand: 'fmt'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        TF_ACTION_WORKING_DIR: .
     - name: terraform-init
-      uses: hashicorp/terraform-github-actions/init@v0.4.0
+      uses: hashicorp/terraform-github-actions@master
+      with:
+        tf_actions_version: 0.12.24
+        tf_actions_subcommand: 'init'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        TF_ACTION_WORKING_DIR: .
     - name: terraform-validate
-      uses: hashicorp/terraform-github-actions/validate@v0.4.0
+      uses: hashicorp/terraform-github-actions@master
+      with:
+        tf_actions_version: 0.12.24
+        tf_actions_subcommand: 'validate'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        TF_ACTION_WORKING_DIR: .

--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ Setting up continuous integration pipeline for your projects can be tricky, but 
 
 ## What's in the box
 
-- A CI workflow that runs the following terraform commands: `fmt`, `init`, and `validate`. All of these actions are configurable, and documentation can be found [here][tfactions_docs]. Warning: the current docs still use HCL (v1) format, you will need to convert the examples to YAML (v2).
- 
+- A CI workflow that runs the following terraform commands: `fmt`, `init`, and `validate`. All of these actions are configurable, and documentation can be found [here][tfactions_docs].
+
 ## What's not in the box
 
 - A Continuous Delivery (CD) pipeline to run the `plan` and `apply` commands. These commands will require additional configuration (cloud vendor secrets) to work and have no place in a template.
@@ -33,7 +33,7 @@ See [LICENSE](LICENSE).
 
 ## Copyright
 
-Mark Sta Ana &copy; 2019 
+Mark Sta Ana &copy; 2020
 
 <!-- linkies -->
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,11 @@ Setting up continuous integration pipeline for your projects can be tricky, but 
 
 - A Continuous Delivery (CD) pipeline to run the `plan` and `apply` commands. These commands will require additional configuration (cloud vendor secrets) to work and have no place in a template.
 
+## Changelog
+
+2020-04-26 - Update to reflect change in GitHub Action usage
+2019-09-28 - Initial release
+
 ## License
 
 See [LICENSE](LICENSE).


### PR DESCRIPTION
actions always use the master branch, and versions and subcommand are specified within the workflow step.

closes #1 